### PR TITLE
build_and_deploy: Don't specify the on events, and require secrets input

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -1,14 +1,12 @@
 name: 'Deploy on release tag'
 
 on:
-  push:
-    tags:
-      - v[0-9]+.[0-9]+.[0-9]+\+?r?e?v?[0-9]?
-      - v20[0-9][0-9].[0-1]?[1470].[0-9]+
-
-    # Allows you to run this workflow manually from the Actions tab
-  workflow_dispatch:
   workflow_call:
+    secrets:
+      jenkins_user:
+        required: true
+      jenkins_token:
+        required: true
 
 jobs:
   fetch:


### PR DESCRIPTION
Let the caller specify both the on event and the workflow_dispatch that
allows running it from the github repository actions tab.

Also, pass the secrets for the caller.

Change-type: patch
Signed-off-by: Alex Gonzalez <alexg@balena.io>