### PR TITLE
workflows: build_and_deploy: Pull action from balena-os

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -79,7 +79,7 @@ jobs:
           echo "Deploying" ${{ matrix.board }}
       - name: Triggers a deploy job
         if: ${{ matrix.board  != null }}
-        uses: alexgg/jenkins-job-action@0.0.9
+        uses: balena-os/jenkins-job-action@0.0.9
         with:
           jenkins_url: "https://jenkins.product-os.io"
           jenkins_user: "${{ secrets.jenkins_user }}"


### PR DESCRIPTION
Stop using a fork in my personal repository and use a fork in balena-os
instead. Once my PR to the upstream repo is merged, we can revert to
using upstream.

Change-type: patch
Signed-off-by: Alex Gonzalez <alexg@balena.io>