### PR TITLE
build_and_deploy: Keep waiting for jobs to complete

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -103,5 +103,5 @@ jobs:
           jenkins_token: "${{ secrets.jenkins_token }}"
           jenkins_use_post_request: 'True'
           job_name: "${{ needs.fetch.outputs.job }}"
-          do_not_wait: '1'
+          job_timeout: 14400
           jenkins_params: '{"board": "${{ matrix.board }}", "tag": "${{  needs.fetch.outputs.tag }}", "deployTo": "${{ inputs.deployTo }}", "final": "${{ inputs.final }}"}'


### PR DESCRIPTION
Using the Yocto cache jobs take between 10/15' to complete, and it's
nice to see workflow status reflecting the builds output.

Unless the hosted processing time spikes up let's keep this setting.

Change-type: patch
Signed-off-by: Alex Gonzalez <alexg@balena.io>