### PR TITLE
workflows: build_and_deploy: use a single prefix for test jobs

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -7,11 +7,11 @@ on:
         required: true
         type: string
         description: balenaCloud environment to deploy to
-      workerType:
-        default: testbot
+      testJobPrefix:
+        default: test
         required: false
         type: string
-        description: Leviathan worker type, can be qemu or testbot.
+        description: Prefix to the test job name
     secrets:
       jenkins_user:
         required: true
@@ -111,9 +111,9 @@ jobs:
         run: |
           prid=$(gh api -H "Accept: application/vnd.github+json" /repos/$REPO/commits/$COMMIT --jq '.commit.message' | head -n1 | cut -d "#" -f2 | awk '{ print $1}')
           status_url=$(gh api -H "Accept: application/vnd.github+json" /repos/$REPO/pulls/$prid --jq '._links.statuses.href')
-          testbot_job="${{ inputs.workerType }}-${{ matrix.board }}"
+          job_prefix="${{ inputs.testJobPrefix }}-${{ matrix.board }}"
           passed="no"
-          if curl -sL "${status_url}" | jq -e '.[] | select(.context == "'"${testbot_job}"'") | select(.description == "OS tests have passed\n ")' > /dev/null 2>&1; then
+          if curl -sL "${status_url}" | jq -e '.[] | select(.context == "'"${job_prefix}"'") | select(.description == "OS tests have passed\n ")' > /dev/null 2>&1; then
             passed="yes"
           fi
           echo "::set-output name=final::${passed}"


### PR DESCRIPTION
Test jobs used to be prefixed by either `testbot` or `qemu` to represent either physical or virtual environments.

This change uses a customizable unique job prefix that defaults to `test` that will be used to define whether to release as final, abstracting the actual run environment from the decision.

Change-type: patch
Signed-off-by: Alex Gonzalez <alexg@balena.io>