### PR TITLE
esr: Allow it to be re-usable

### DIFF
--- a/.github/workflows/esr.yml
+++ b/.github/workflows/esr.yml
@@ -1,6 +1,16 @@
 name: 'Create ESR branch and tag'
 
 on:
+  workflow_call:
+    inputs:
+      esr-version:
+        required: false
+        type: string
+        description: ESR version override, for example 2022.10. By default it uses the current year and month.
+      os-version:
+        required: false
+        type: string
+        description: OS ESR version override, for example 2.104. By default it uses the latest ESR branch.
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
Add a workflow_call on event so it can be reused by multiple device repositories.

Change-type: patch
Signed-off-by: Alex Gonzalez <alexg@balena.io>