### PR TITLE
esr: remove dispatch event from re-usable workflow

### DIFF
--- a/.github/workflows/esr.yml
+++ b/.github/workflows/esr.yml
@@ -11,17 +11,6 @@ on:
         required: false
         type: string
         description: OS ESR version override, for example 2.104. By default it uses the latest ESR branch.
-  # Allows you to run this workflow manually from the Actions tab
-  workflow_dispatch:
-    inputs:
-      esr-version:
-        required: false
-        type: string
-        description: ESR version override, for example 2022.10. By default it uses the current year and month.
-      os-version:
-        required: false
-        type: string
-        description: OS ESR version override, for example 2.104. By default it uses the latest ESR branch.
 
 jobs:
   fetch:


### PR DESCRIPTION
The dispatch event belongs on the calling workflows.

Change-type: patch
Signed-off-by: Alex Gonzalez <alexg@balena.io>