### PR TITLE
Remove excessive permissions from app token

### DIFF
--- a/.github/workflows/esr.yml
+++ b/.github/workflows/esr.yml
@@ -31,15 +31,9 @@ jobs:
           private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
           permissions: >-
             {
-              "actions": "read",
-              "administration": "read",
-              "checks": "read",
               "contents": "write",
-              "members": "read",
               "metadata": "read",
-              "pull_requests": "write",
-              "statuses": "read",
-              "workflows": "read"
+              "pull_requests": "write"
             }
 
       - uses: actions/checkout@v3


### PR DESCRIPTION
These permissions have already been removed from
flowzone-app[bot] so requesting them at runtime will fail.

Change-type: patch