### PR TITLE
use gh token to authenticate curl to status url

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -113,7 +113,7 @@ jobs:
           status_url=$(gh api -H "Accept: application/vnd.github+json" /repos/$REPO/pulls/$prid --jq '._links.statuses.href')
           job_prefix="${{ inputs.testJobPrefix }}-${{ matrix.board }}"
           passed="no"
-          if curl -sL "${status_url}" | jq -e '.[] | select(.context == "'"${job_prefix}"'") | select(.description == "OS tests have passed\n ")' > /dev/null 2>&1; then
+          if curl -sL "${status_url}" --header "Authorization: Bearer $GH_TOKEN" | jq -e '.[] | select(.context == "'"${job_prefix}"'") | select(.description == "OS tests have passed\n ")' > /dev/null 2>&1; then
             passed="yes"
           fi
           echo "::set-output name=final::${passed}"


### PR DESCRIPTION
When using this action with a private repo, the curl request to the status check url fails because there it doesn't authenticate. This will cause private DT's to never be deployed to production. 

Added the authentication using the github token env var that is used elsewhere in the action. 

Change-type: patch