### PR TITLE
workflows: Switch to balenaOS ESR [bot] for authentication

### DIFF
--- a/.github/workflows/esr.yml
+++ b/.github/workflows/esr.yml
@@ -12,6 +12,14 @@ on:
         type: string
         description: OS ESR version override, for example 2.104. By default it uses the latest ESR branch.
 
+env:
+  # get the user id of the GitHub App
+  # gh api /users/balenaos-esr%5Bbot%5D
+  GIT_AUTHOR_NAME: balenaos-esr-bot[bot]
+  GIT_AUTHOR_EMAIL: 146746583+balenaos-esr-bot[bot]@users.noreply.github.com
+  GIT_COMMITTER_NAME: balenaos-esr-bot[bot]
+  GIT_COMMITTER_EMAIL: 146746583+balenaos-esr-bot[bot]@users.noreply.github.com
+
 jobs:
   fetch:
     runs-on: ubuntu-latest
@@ -22,19 +30,15 @@ jobs:
       status: ${{ join(steps.*.conclusion) }}
     steps:
       - name: Generate GitHub App installation token
-        uses: tibdex/github-app-token@b62528385c34dbc9f38e5f4225ac829252d1ea92 # v1.8.0
-        continue-on-error: true
+        uses: tibdex/github-app-token@0914d50df753bbc42180d982a6550f195390069f # v2.0.0
         id: gh_app_token
         with:
-          app_id: ${{ vars.APP_ID || '291899' }}
-          installation_id: ${{ vars.INSTALLATION_ID || '34046907' }}
-          private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
-          permissions: >-
-            {
-              "contents": "write",
-              "metadata": "read",
-              "pull_requests": "write"
-            }
+          app_id: ${{ vars.ESR_BOT_APP_ID || '400859' }}
+          installation_retrieval_mode: organization
+          installation_retrieval_payload: ${{ github.event.repository.owner.login }}
+          private_key: ${{ secrets.ESR_BOT_PRIVATE_KEY }}
+          repositories: >
+            ["${{ github.event.repository.name }}"]
 
       - uses: actions/checkout@v3
         with:
@@ -193,8 +197,6 @@ jobs:
                   modified.write("".join(prefix))
           EOF
           git add VERSION CHANGELOG.md repo.yml layers/meta-balena
-          git config --global user.name 'flowzone-app[bot]'
-          git config --global user.email '124931076+flowzone-app[bot]@users.noreply.github.com'
           git commit -F- <<-EOF
           Declare ESR ${{ steps.check-esr-branch.outputs.esr_version }}
 


### PR DESCRIPTION
Flowzone App no longer has workflow:write permissions for security reasons.

This new balenaOS ESR bot has contents:write and workflows:write permissions but is only available on balenaOS repositories.

See: https://github.com/apps/balenaos-esr
Change-type: patch